### PR TITLE
Port django-mobile to Django 2.2/3.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
 .tox/
+__pycache__/
+*.egg-info/
+/.coverage
+/dist/
+/build/
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,3 @@ before_install:
   - sudo pip install tox
 script:
   - tox -e $TOX_ENV
-#deploy:
-#  provider: pypi
-#  user: kaniabi
-#  password:
-#    secure: mT6Gzp14P5GuWUi0MlXiBZuH6pb6M6daPe350BLo+66DQ/s1RMqqBU3lu7KTaNIKui1ZoitfNyiMiQ0QYP3+4RvR2/9HK9BEqVY7lK5mDxRWxDr1lVUnV3Bg37Vqj8792xdstDbRwP7/EkZEuviTTWAMEbYE8YJu4M/XLWpgnYY=
-#  on:
-#    tags: true
-#    repo: zerotk/django-mobile
-#    condition: "$TOX_ENV = py36"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,19 @@
 language: python
+dist: bionic
 env:
-  - TOX_ENV=py26-15
-  - TOX_ENV=py26-16
-  - TOX_ENV=py27-15
-  - TOX_ENV=py27-16
-  - TOX_ENV=py27-17
-  - TOX_ENV=py27-18
-  - TOX_ENV=py27-19
-  - TOX_ENV=py33-17
-  - TOX_ENV=py33-18
-  - TOX_ENV=py34-17
-  - TOX_ENV=py34-18
-  - TOX_ENV=py34-19
-  - TOX_ENV=pypy-15
-  - TOX_ENV=pypy-16
-  - TOX_ENV=pypy-17
-  - TOX_ENV=pypy-18
-  - TOX_ENV=pypy-19
+  - TOX_ENV=py36
+  - TOX_ENV=py37
+  - TOX_ENV=py38
 before_install:
   - sudo pip install tox
 script:
   - tox -e $TOX_ENV
-deploy:
-  provider: pypi
-  user: gremu
-  password:
-    secure: mT6Gzp14P5GuWUi0MlXiBZuH6pb6M6daPe350BLo+66DQ/s1RMqqBU3lu7KTaNIKui1ZoitfNyiMiQ0QYP3+4RvR2/9HK9BEqVY7lK5mDxRWxDr1lVUnV3Bg37Vqj8792xdstDbRwP7/EkZEuviTTWAMEbYE8YJu4M/XLWpgnYY=
-  on:
-    tags: true
-    repo: gregmuellegger/django-mobile
-    condition: "$TOX_ENV = py34-18"
+#deploy:
+#  provider: pypi
+#  user: kaniabi
+#  password:
+#    secure: mT6Gzp14P5GuWUi0MlXiBZuH6pb6M6daPe350BLo+66DQ/s1RMqqBU3lu7KTaNIKui1ZoitfNyiMiQ0QYP3+4RvR2/9HK9BEqVY7lK5mDxRWxDr1lVUnV3Bg37Vqj8792xdstDbRwP7/EkZEuviTTWAMEbYE8YJu4M/XLWpgnYY=
+#  on:
+#    tags: true
+#    repo: zerotk/django-mobile
+#    condition: "$TOX_ENV = py36"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,13 @@
 language: python
 dist: bionic
-env:
-  - TOX_ENV=py36
-  - TOX_ENV=py37
-  - TOX_ENV=py38
+matrix:
+  include:
+    - python: 3.6
+      env: TOX_ENV=py36
+    - python: 3.7
+      env: TOX_ENV=py37
+    - python: 3.8
+      env: TOX_ENV=py38
 before_install:
   - sudo pip install tox
 script:

--- a/django_mobile/__init__.py
+++ b/django_mobile/__init__.py
@@ -53,8 +53,8 @@ class ProxyBackend(object):
         backend = settings.FLAVOURS_STORAGE_BACKEND
         if not settings.FLAVOURS_STORAGE_BACKEND:
             raise ImproperlyConfigured(
-                u"You must specify a FLAVOURS_STORAGE_BACKEND setting to "
-                u"save the flavour for a user."
+                "You must specify a FLAVOURS_STORAGE_BACKEND setting to "
+                "save the flavour for a user."
             )
         return FLAVOUR_STORAGE_BACKENDS[backend]
 
@@ -98,7 +98,7 @@ def get_flavour(request=None, default=None):
 def set_flavour(flavour, request=None, permanent=False):
     if flavour not in settings.FLAVOURS:
         raise ValueError(
-            u"'%r' is no valid flavour. Allowed flavours are: %s"
+            "'%r' is no valid flavour. Allowed flavours are: %s"
             % (flavour, ", ".join(settings.FLAVOURS),)
         )
     request = request or getattr(_local, "request", None)
@@ -107,7 +107,7 @@ def set_flavour(flavour, request=None, permanent=False):
         if permanent:
             flavour_storage.set(request, flavour)
     elif permanent:
-        raise ValueError(u"Cannot set flavour permanently, no request available.")
+        raise ValueError("Cannot set flavour permanently, no request available.")
     _local.flavour = flavour
 
 

--- a/django_mobile/cache/__init__.py
+++ b/django_mobile/cache/__init__.py
@@ -2,9 +2,12 @@ from functools import wraps
 
 from django.views.decorators.cache import cache_page as _django_cache_page
 from django.utils.decorators import decorator_from_middleware
-from django_mobile.cache.middleware import FetchFromCacheFlavourMiddleware, UpdateCacheFlavourMiddleware
+from django_mobile.cache.middleware import (
+    FetchFromCacheFlavourMiddleware,
+    UpdateCacheFlavourMiddleware,
+)
 
-__all__ = ('cache_page', 'vary_on_flavour_fetch', 'vary_on_flavour_update')
+__all__ = ("cache_page", "vary_on_flavour_fetch", "vary_on_flavour_update")
 
 
 vary_on_flavour_fetch = decorator_from_middleware(FetchFromCacheFlavourMiddleware)
@@ -12,13 +15,15 @@ vary_on_flavour_update = decorator_from_middleware(UpdateCacheFlavourMiddleware)
 
 
 def cache_page(*args, **kwargs):
-    '''
+    """
     Same as django's ``cache_page`` decorator, but wraps the view into
     additional decorators before and after that. Makes it possible to serve multiple
     flavours without getting into trouble with django's caching that doesn't
     know about flavours.
-    '''
+    """
     decorator = _django_cache_page(*args, **kwargs)
+
     def flavoured_decorator(func):
         return vary_on_flavour_fetch(decorator(vary_on_flavour_update(func)))
+
     return flavoured_decorator

--- a/django_mobile/cache/middleware.py
+++ b/django_mobile/cache/middleware.py
@@ -6,11 +6,13 @@ from django_mobile import get_flavour, _set_request_header
 
 class CacheFlavourMiddleware(object):
     def __init__(self):
-        warnings.warn('CacheFlavourMiddleware does nothing and should be abandoned.'
-                      'The intended behavior cannot be implemented using one middleware.'
-                      'Use separate FetchFromCacheFlavourMiddleware and UpdateCacheFlavourMiddleware instead.'
-                      'Refer to https://github.com/gregmuellegger/django-mobile/pull/64 for details',
-                      category=DeprecationWarning)
+        warnings.warn(
+            "CacheFlavourMiddleware does nothing and should be abandoned."
+            "The intended behavior cannot be implemented using one middleware."
+            "Use separate FetchFromCacheFlavourMiddleware and UpdateCacheFlavourMiddleware instead."
+            "Refer to https://github.com/gregmuellegger/django-mobile/pull/64 for details",
+            category=DeprecationWarning,
+        )
 
 
 class FetchFromCacheFlavourMiddleware(object):
@@ -20,5 +22,5 @@ class FetchFromCacheFlavourMiddleware(object):
 
 class UpdateCacheFlavourMiddleware(object):
     def process_response(self, request, response):
-        patch_vary_headers(response, ['X-Flavour'])
+        patch_vary_headers(response, ["X-Flavour"])
         return response

--- a/django_mobile/compat.py
+++ b/django_mobile/compat.py
@@ -3,7 +3,11 @@ try:
     from django.template.loaders.base import Loader as BaseLoader
 except ImportError:  # Django < 1.8
     Engine = None
-    from django.template.loader import BaseLoader, find_template_loader, get_template_from_string
+    from django.template.loader import (
+        BaseLoader,
+        find_template_loader,
+        get_template_from_string,
+    )
 
 
 def template_loader(loader_name):

--- a/django_mobile/conf.py
+++ b/django_mobile/conf.py
@@ -30,7 +30,7 @@ class defaults(object):
     FLAVOURS_COOKIE_HTTPONLY = False
     FLAVOURS_SESSION_KEY = u'flavour'
     FLAVOURS_TEMPLATE_LOADERS = []
-    for loader in django_settings.TEMPLATE_LOADERS:
+    for loader in django_settings.TEMPLATES[0]['OPTIONS']['loaders']:
         if isinstance(loader, (tuple, list)) and loader[0] == CACHE_LOADER_NAME:
             for cached_loader in loader[1]:
                 if cached_loader != DJANGO_MOBILE_LOADER:

--- a/django_mobile/conf.py
+++ b/django_mobile/conf.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 from django.conf import settings as django_settings
 
-CACHE_LOADER_NAME = 'django_mobile.loader.CachedLoader'
-DJANGO_MOBILE_LOADER = 'django_mobile.loader.Loader'
+CACHE_LOADER_NAME = "django_mobile.loader.CachedLoader"
+DJANGO_MOBILE_LOADER = "django_mobile.loader.Loader"
 
 
 class SettingsProxy(object):
@@ -21,16 +21,19 @@ class SettingsProxy(object):
 
 
 class defaults(object):
-    FLAVOURS = (u'full', u'mobile',)
-    DEFAULT_MOBILE_FLAVOUR = u'mobile'
-    FLAVOURS_TEMPLATE_PREFIX = u''
-    FLAVOURS_GET_PARAMETER = u'flavour'
-    FLAVOURS_STORAGE_BACKEND = u'cookie'
-    FLAVOURS_COOKIE_KEY = u'flavour'
+    FLAVOURS = (
+        u"full",
+        u"mobile",
+    )
+    DEFAULT_MOBILE_FLAVOUR = u"mobile"
+    FLAVOURS_TEMPLATE_PREFIX = u""
+    FLAVOURS_GET_PARAMETER = u"flavour"
+    FLAVOURS_STORAGE_BACKEND = u"cookie"
+    FLAVOURS_COOKIE_KEY = u"flavour"
     FLAVOURS_COOKIE_HTTPONLY = False
-    FLAVOURS_SESSION_KEY = u'flavour'
+    FLAVOURS_SESSION_KEY = u"flavour"
     FLAVOURS_TEMPLATE_LOADERS = []
-    for loader in django_settings.TEMPLATES[0]['OPTIONS']['loaders']:
+    for loader in django_settings.TEMPLATES[0]["OPTIONS"]["loaders"]:
         if isinstance(loader, (tuple, list)) and loader[0] == CACHE_LOADER_NAME:
             for cached_loader in loader[1]:
                 if cached_loader != DJANGO_MOBILE_LOADER:
@@ -38,5 +41,6 @@ class defaults(object):
         elif loader != DJANGO_MOBILE_LOADER:
             FLAVOURS_TEMPLATE_LOADERS.append(loader)
     FLAVOURS_TEMPLATE_LOADERS = tuple(FLAVOURS_TEMPLATE_LOADERS)
+
 
 settings = SettingsProxy(django_settings, defaults)

--- a/django_mobile/conf.py
+++ b/django_mobile/conf.py
@@ -17,21 +17,21 @@ class SettingsProxy(object):
             try:
                 return getattr(self.defaults, attr)
             except AttributeError:
-                raise AttributeError(u'settings object has no attribute "%s"' % attr)
+                raise AttributeError('settings object has no attribute "%s"' % attr)
 
 
 class defaults(object):
     FLAVOURS = (
-        u"full",
-        u"mobile",
+        "full",
+        "mobile",
     )
-    DEFAULT_MOBILE_FLAVOUR = u"mobile"
-    FLAVOURS_TEMPLATE_PREFIX = u""
-    FLAVOURS_GET_PARAMETER = u"flavour"
-    FLAVOURS_STORAGE_BACKEND = u"cookie"
-    FLAVOURS_COOKIE_KEY = u"flavour"
+    DEFAULT_MOBILE_FLAVOUR = "mobile"
+    FLAVOURS_TEMPLATE_PREFIX = ""
+    FLAVOURS_GET_PARAMETER = "flavour"
+    FLAVOURS_STORAGE_BACKEND = "cookie"
+    FLAVOURS_COOKIE_KEY = "flavour"
     FLAVOURS_COOKIE_HTTPONLY = False
-    FLAVOURS_SESSION_KEY = u"flavour"
+    FLAVOURS_SESSION_KEY = "flavour"
     FLAVOURS_TEMPLATE_LOADERS = []
     for loader in django_settings.TEMPLATES[0]["OPTIONS"]["loaders"]:
         if isinstance(loader, (tuple, list)) and loader[0] == CACHE_LOADER_NAME:

--- a/django_mobile/context_processors.py
+++ b/django_mobile/context_processors.py
@@ -4,11 +4,11 @@ from django_mobile.conf import settings
 
 def flavour(request):
     return {
-        'flavour': get_flavour(),
+        "flavour": get_flavour(),
     }
 
 
 def is_mobile(request):
     return {
-        'is_mobile': get_flavour() == settings.DEFAULT_MOBILE_FLAVOUR,
+        "is_mobile": get_flavour() == settings.DEFAULT_MOBILE_FLAVOUR,
     }

--- a/django_mobile/loader.py
+++ b/django_mobile/loader.py
@@ -14,48 +14,39 @@ class Loader(BaseLoader):
     def get_contents(self, origin):
         return origin.loader.get_contents(origin)
 
-    def get_template_sources(self, template_name, template_dirs=None):
-        template_name = self.prepare_template_name(template_name)
-        for loader in self.template_source_loaders:
-            if hasattr(loader, 'get_template_sources'):
-                try:
-                    for result in loader.get_template_sources(template_name, template_dirs):
-                        yield result
-                except UnicodeDecodeError:
-                    # The template dir name was a bytestring that wasn't valid UTF-8.
-                    raise
-                except ValueError:
-                    # The joined path was located outside of this particular
-                    # template_dir (it might be inside another one, so this isn't
-                    # fatal).
-                    pass
-
-    def prepare_template_name(self, template_name):
-        template_name = u'%s/%s' % (get_flavour(), template_name)
-        if settings.FLAVOURS_TEMPLATE_PREFIX:
-            template_name = settings.FLAVOURS_TEMPLATE_PREFIX + template_name
-        return template_name
-
-    def load_template(self, template_name, template_dirs=None):
-        template_name = self.prepare_template_name(template_name)
+    def get_template_sources(self, template_name):
+        template_name = self._prepare_template_name(template_name)
         for loader in self.template_source_loaders:
             try:
-                return loader(template_name, template_dirs)
+                for result in loader.get_template_sources(template_name):
+                    yield result
+            except UnicodeDecodeError:
+                # The template dir name was a bytestring that wasn't valid UTF-8.
+                raise
+            except ValueError:
+                # The joined path was located outside of this particular
+                # template_dir (it might be inside another one, so this isn't
+                # fatal).
+                pass
+
+    def get_template(self, template_name, skip=None):
+        """Iterate over configured loaders (FLAVOURS_TEMPLATE_LOADERS)
+        and return the value from the first one to find the template.
+        """
+        template_name = self._prepare_template_name(template_name)
+        for loader in self.template_source_loaders:
+            try:
+                return loader.get_template(template_name, skip)
             except TemplateDoesNotExist:
                 pass
         raise TemplateDoesNotExist("Tried %s" % template_name)
 
-    def load_template_source(self, template_name, template_dirs=None):
-        template_name = self.prepare_template_name(template_name)
-        for loader in self.template_source_loaders:
-            if hasattr(loader, 'load_template_source'):
-                try:
-                    return loader.load_template_source(
-                        template_name,
-                        template_dirs)
-                except TemplateDoesNotExist:
-                    pass
-        raise TemplateDoesNotExist("Tried %s" % template_name)
+    def _prepare_template_name(self, template_name):
+        """Prepare the template name taking into consideration the flavor."""
+        template_name = u"%s/%s" % (get_flavour(), template_name)
+        if settings.FLAVOURS_TEMPLATE_PREFIX:
+            template_name = settings.FLAVOURS_TEMPLATE_PREFIX + template_name
+        return template_name
 
     @property
     def template_source_loaders(self):
@@ -72,38 +63,7 @@ class Loader(BaseLoader):
 class CachedLoader(DjangoCachedLoader):
     is_usable = True
 
-    def cache_key(self, template_name, template_dirs, *args):
-        if len(args) > 0:  # Django >= 1.9
-            key = super(CachedLoader, self).cache_key(template_name, template_dirs, *args)
-        else:
-            if template_dirs:
-                key = '-'.join([
-                    template_name,
-                    hashlib.sha1(force_bytes('|'.join(template_dirs))).hexdigest()
-                ])
-            else:
-                key = template_name
-
-        return '{0}:{1}'.format(get_flavour(), key)
-
-    def load_template(self, template_name, template_dirs=None):
-        key = self.cache_key(template_name, template_dirs)
-        template_tuple = self.template_cache.get(key)
-
-        if template_tuple is TemplateDoesNotExist:
-            raise TemplateDoesNotExist('Template not found: %s' % template_name)
-        elif template_tuple is None:
-            template, origin = self.find_template(template_name, template_dirs)
-            if not hasattr(template, 'render'):
-                try:
-                    template = template_from_string(template)
-                except TemplateDoesNotExist:
-                    # If compiling the template we found raises TemplateDoesNotExist,
-                    # back off to returning the source and display name for the template
-                    # we were asked to load. This allows for correct identification (later)
-                    # of the actual template that does not exist.
-                    self.template_cache[key] = (template, origin)
-
-            self.template_cache[key] = (template, None)
-
-        return self.template_cache[key]
+    def cache_key(self, template_name, skip):
+        """Add flavour to the cache-key."""
+        result = super().cache_key(template_name, skip)
+        return "{0}:{1}".format(get_flavour(), result)

--- a/django_mobile/loader.py
+++ b/django_mobile/loader.py
@@ -43,7 +43,7 @@ class Loader(BaseLoader):
 
     def _prepare_template_name(self, template_name):
         """Prepare the template name taking into consideration the flavor."""
-        template_name = u"%s/%s" % (get_flavour(), template_name)
+        template_name = "%s/%s" % (get_flavour(), template_name)
         if settings.FLAVOURS_TEMPLATE_PREFIX:
             template_name = settings.FLAVOURS_TEMPLATE_PREFIX + template_name
         return template_name

--- a/django_mobile/middleware.py
+++ b/django_mobile/middleware.py
@@ -21,53 +21,143 @@ class SetFlavourMiddleware(MiddlewareMixin):
 
 class MobileDetectionMiddleware(MiddlewareMixin):
     user_agents_test_match = (
-        "w3c ", "acs-", "alav", "alca", "amoi", "audi",
-        "avan", "benq", "bird", "blac", "blaz", "brew",
-        "cell", "cldc", "cmd-", "dang", "doco", "eric",
-        "hipt", "inno", "ipaq", "java", "jigs", "kddi",
-        "keji", "leno", "lg-c", "lg-d", "lg-g", "lge-",
-        "maui", "maxo", "midp", "mits", "mmef", "mobi",
-        "mot-", "moto", "mwbp", "nec-", "newt", "noki",
-        "xda",  "palm", "pana", "pant", "phil", "play",
-        "port", "prox", "qwap", "sage", "sams", "sany",
-        "sch-", "sec-", "send", "seri", "sgh-", "shar",
-        "sie-", "siem", "smal", "smar", "sony", "sph-",
-        "symb", "t-mo", "teli", "tim-", "tosh", "tsm-",
-        "upg1", "upsi", "vk-v", "voda", "wap-", "wapa",
-        "wapi", "wapp", "wapr", "webc", "winw", "xda-",)
-    user_agents_test_search = u"(?:%s)" % u'|'.join((
-        'up.browser', 'up.link', 'mmp', 'symbian', 'smartphone', 'midp',
-        'wap', 'phone', 'windows ce', 'pda', 'mobile', 'mini', 'palm',
-        'netfront', 'opera mobi',
-    ))
-    user_agents_exception_search = u"(?:%s)" % u'|'.join((
-        'ipad',
-    ))
+        "w3c ",
+        "acs-",
+        "alav",
+        "alca",
+        "amoi",
+        "audi",
+        "avan",
+        "benq",
+        "bird",
+        "blac",
+        "blaz",
+        "brew",
+        "cell",
+        "cldc",
+        "cmd-",
+        "dang",
+        "doco",
+        "eric",
+        "hipt",
+        "inno",
+        "ipaq",
+        "java",
+        "jigs",
+        "kddi",
+        "keji",
+        "leno",
+        "lg-c",
+        "lg-d",
+        "lg-g",
+        "lge-",
+        "maui",
+        "maxo",
+        "midp",
+        "mits",
+        "mmef",
+        "mobi",
+        "mot-",
+        "moto",
+        "mwbp",
+        "nec-",
+        "newt",
+        "noki",
+        "xda",
+        "palm",
+        "pana",
+        "pant",
+        "phil",
+        "play",
+        "port",
+        "prox",
+        "qwap",
+        "sage",
+        "sams",
+        "sany",
+        "sch-",
+        "sec-",
+        "send",
+        "seri",
+        "sgh-",
+        "shar",
+        "sie-",
+        "siem",
+        "smal",
+        "smar",
+        "sony",
+        "sph-",
+        "symb",
+        "t-mo",
+        "teli",
+        "tim-",
+        "tosh",
+        "tsm-",
+        "upg1",
+        "upsi",
+        "vk-v",
+        "voda",
+        "wap-",
+        "wapa",
+        "wapi",
+        "wapp",
+        "wapr",
+        "webc",
+        "winw",
+        "xda-",
+    )
+    user_agents_test_search = u"(?:%s)" % u"|".join(
+        (
+            "up.browser",
+            "up.link",
+            "mmp",
+            "symbian",
+            "smartphone",
+            "midp",
+            "wap",
+            "phone",
+            "windows ce",
+            "pda",
+            "mobile",
+            "mini",
+            "palm",
+            "netfront",
+            "opera mobi",
+        )
+    )
+    user_agents_exception_search = u"(?:%s)" % u"|".join(("ipad",))
     http_accept_regex = re.compile("application/vnd\.wap\.xhtml\+xml", re.IGNORECASE)
 
     def __init__(self, get_response=None):
         super(MobileDetectionMiddleware, self).__init__(get_response)
-        user_agents_test_match = r'^(?:%s)' % '|'.join(self.user_agents_test_match)
-        self.user_agents_test_match_regex = re.compile(user_agents_test_match, re.IGNORECASE)
-        self.user_agents_test_search_regex = re.compile(self.user_agents_test_search, re.IGNORECASE)
-        self.user_agents_exception_search_regex = re.compile(self.user_agents_exception_search, re.IGNORECASE)
+        user_agents_test_match = r"^(?:%s)" % "|".join(self.user_agents_test_match)
+        self.user_agents_test_match_regex = re.compile(
+            user_agents_test_match, re.IGNORECASE
+        )
+        self.user_agents_test_search_regex = re.compile(
+            self.user_agents_test_search, re.IGNORECASE
+        )
+        self.user_agents_exception_search_regex = re.compile(
+            self.user_agents_exception_search, re.IGNORECASE
+        )
 
     def process_request(self, request):
         is_mobile = False
 
-        if 'HTTP_USER_AGENT' in request.META :
-            user_agent = request.META['HTTP_USER_AGENT']
+        if "HTTP_USER_AGENT" in request.META:
+            user_agent = request.META["HTTP_USER_AGENT"]
 
             # Test common mobile values.
-            if self.user_agents_test_search_regex.search(user_agent) and \
-                not self.user_agents_exception_search_regex.search(user_agent):
+            if self.user_agents_test_search_regex.search(
+                user_agent
+            ) and not self.user_agents_exception_search_regex.search(user_agent):
                 is_mobile = True
             else:
                 # Nokia like test for WAP browsers.
                 # http://www.developershome.com/wap/xhtmlmp/xhtml_mp_tutorial.asp?page=mimeTypesFileExtension
 
-                if 'HTTP_ACCEPT' in request.META :
-                    http_accept = request.META['HTTP_ACCEPT']
+                if "HTTP_ACCEPT" in request.META:
+                    http_accept = request.META["HTTP_ACCEPT"]
                     if self.http_accept_regex.search(http_accept):
                         is_mobile = True
 

--- a/django_mobile/middleware.py
+++ b/django_mobile/middleware.py
@@ -2,9 +2,10 @@ import re
 from django_mobile import flavour_storage
 from django_mobile import set_flavour, _init_flavour
 from django_mobile.conf import settings
+from django.utils.deprecation import MiddlewareMixin
 
 
-class SetFlavourMiddleware(object):
+class SetFlavourMiddleware(MiddlewareMixin):
     def process_request(self, request):
         _init_flavour(request)
 
@@ -18,7 +19,7 @@ class SetFlavourMiddleware(object):
         return response
 
 
-class MobileDetectionMiddleware(object):
+class MobileDetectionMiddleware(MiddlewareMixin):
     user_agents_test_match = (
         "w3c ", "acs-", "alav", "alca", "amoi", "audi",
         "avan", "benq", "bird", "blac", "blaz", "brew",
@@ -44,7 +45,8 @@ class MobileDetectionMiddleware(object):
     ))
     http_accept_regex = re.compile("application/vnd\.wap\.xhtml\+xml", re.IGNORECASE)
 
-    def __init__(self):
+        def __init__(self, get_response=None):
+        super(MobileDetectionMiddleware, self).__init__(get_response)
         user_agents_test_match = r'^(?:%s)' % '|'.join(self.user_agents_test_match)
         self.user_agents_test_match_regex = re.compile(user_agents_test_match, re.IGNORECASE)
         self.user_agents_test_search_regex = re.compile(self.user_agents_test_search, re.IGNORECASE)

--- a/django_mobile/middleware.py
+++ b/django_mobile/middleware.py
@@ -45,7 +45,7 @@ class MobileDetectionMiddleware(MiddlewareMixin):
     ))
     http_accept_regex = re.compile("application/vnd\.wap\.xhtml\+xml", re.IGNORECASE)
 
-        def __init__(self, get_response=None):
+    def __init__(self, get_response=None):
         super(MobileDetectionMiddleware, self).__init__(get_response)
         user_agents_test_match = r'^(?:%s)' % '|'.join(self.user_agents_test_match)
         self.user_agents_test_match_regex = re.compile(user_agents_test_match, re.IGNORECASE)

--- a/django_mobile/middleware.py
+++ b/django_mobile/middleware.py
@@ -106,7 +106,7 @@ class MobileDetectionMiddleware(MiddlewareMixin):
         "winw",
         "xda-",
     )
-    user_agents_test_search = u"(?:%s)" % u"|".join(
+    user_agents_test_search = "(?:%s)" % u"|".join(
         (
             "up.browser",
             "up.link",
@@ -125,7 +125,7 @@ class MobileDetectionMiddleware(MiddlewareMixin):
             "opera mobi",
         )
     )
-    user_agents_exception_search = u"(?:%s)" % u"|".join(("ipad",))
+    user_agents_exception_search = "(?:%s)" % u"|".join(("ipad",))
     http_accept_regex = re.compile("application/vnd\.wap\.xhtml\+xml", re.IGNORECASE)
 
     def __init__(self, get_response=None):

--- a/django_mobile_tests/cache_settings.py
+++ b/django_mobile_tests/cache_settings.py
@@ -2,8 +2,10 @@ from settings import *
 
 
 MIDDLEWARE_CLASSES = (
-    'django.middleware.cache.UpdateCacheMiddleware',
-) + MIDDLEWARE_CLASSES + (
-    'django_mobile.cache.middleware.CacheFlavourMiddleware',
-    'django.middleware.cache.FetchFromCacheMiddleware',
+    ("django.middleware.cache.UpdateCacheMiddleware",)
+    + MIDDLEWARE_CLASSES
+    + (
+        "django_mobile.cache.middleware.CacheFlavourMiddleware",
+        "django.middleware.cache.FetchFromCacheMiddleware",
+    )
 )

--- a/django_mobile_tests/manage.py
+++ b/django_mobile_tests/manage.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python
 import os, sys
 
-os.environ['DJANGO_SETTINGS_MODULE'] = 'django_mobile_tests.settings'
+os.environ["DJANGO_SETTINGS_MODULE"] = "django_mobile_tests.settings"
 parent = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 sys.path.insert(0, parent)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     from django.core.management import execute_from_command_line
-    execute_from_command_line()
 
+    execute_from_command_line()

--- a/django_mobile_tests/settings.py
+++ b/django_mobile_tests/settings.py
@@ -2,14 +2,14 @@ import os
 import warnings
 
 
-warnings.simplefilter('always')
+warnings.simplefilter("always")
 
 PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))
 
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(PROJECT_ROOT, 'db.sqlite'),
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": os.path.join(PROJECT_ROOT, "db.sqlite"),
     }
 }
 
@@ -25,71 +25,75 @@ USE_L10N = True
 
 # Absolute path to the directory that holds media.
 # Example: "/home/media/media.lawrence.com/"
-MEDIA_ROOT = os.path.join(PROJECT_ROOT, 'media')
+MEDIA_ROOT = os.path.join(PROJECT_ROOT, "media")
 
 # URL that handles the media served from MEDIA_ROOT. Make sure to use a
 # trailing slash if there is a path component (optional in other cases).
 # Examples: "http://media.lawrence.com", "http://example.com/media/"
-MEDIA_URL = '/media/'
+MEDIA_URL = "/media/"
 
 # URL prefix for admin media -- CSS, JavaScript and images. Make sure to use a
 # trailing slash.
 # Examples: "http://foo.com/media/", "/media/".
-ADMIN_MEDIA_PREFIX = '/media/admin/'
+ADMIN_MEDIA_PREFIX = "/media/admin/"
 
 # Make this unique, and don't share it with anybody.
-SECRET_KEY = '0'
+SECRET_KEY = "0"
 
-ROOT_URLCONF = 'django_mobile_tests.urls'
+ROOT_URLCONF = "django_mobile_tests.urls"
 
 TEMPLATES = [
     {
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [
-            os.path.join(PROJECT_ROOT, 'templates'),
-        ],
-        'OPTIONS': {
-            'context_processors': [
-                 "django.contrib.auth.context_processors.auth",
-                "django.core.context_processors.debug",
-                "django.core.context_processors.i18n",
-                "django.core.context_processors.media",
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [os.path.join(PROJECT_ROOT, "templates"),],
+        "OPTIONS": {
+            "context_processors": [
+                "django.contrib.auth.context_processors.auth",
+                "django.template.context_processors.debug",
+                "django.template.context_processors.i18n",
+                "django.template.context_processors.media",
                 "django_mobile.context_processors.flavour",
                 "django_mobile.context_processors.is_mobile",
+                "django.contrib.messages.context_processors.messages",
             ],
-            'loaders': [
-                ('django_mobile.loader.CachedLoader', (
-                    'django_mobile.loader.Loader',
-                    'django.template.loaders.filesystem.Loader',
-                    'django.template.loaders.app_directories.Loader',
-                )),
-            ]
-        }
+            "loaders": [
+                (
+                    "django_mobile.loader.CachedLoader",
+                    (
+                        "django_mobile.loader.Loader",
+                        "django.template.loaders.filesystem.Loader",
+                        "django.template.loaders.app_directories.Loader",
+                    ),
+                ),
+            ],
+        },
     }
 ]
 
 MIDDLEWARE = (
-    'django.middleware.common.CommonMiddleware',
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django_mobile.middleware.MobileDetectionMiddleware',
-    'django_mobile.middleware.SetFlavourMiddleware',
+    "django.middleware.common.CommonMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django_mobile.middleware.MobileDetectionMiddleware",
+    "django_mobile.middleware.SetFlavourMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
 )
 
 INSTALLED_APPS = (
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'django.contrib.sessions',
-    'django.contrib.sites',
-    'django.contrib.admin',
-
-    'django_mobile',
-    'django_mobile_tests',
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.sites",
+    "django.contrib.admin",
+    "django.contrib.messages",
+    "django_mobile",
+    "django_mobile_tests",
 )
 
 
 import django
+
 if django.VERSION < (1, 6):
-    TEST_RUNNER = 'discover_runner.DiscoverRunner'
+    TEST_RUNNER = "discover_runner.DiscoverRunner"
 else:
-    TEST_RUNNER = 'django.test.runner.DiscoverRunner'
+    TEST_RUNNER = "django.test.runner.DiscoverRunner"

--- a/django_mobile_tests/settings.py
+++ b/django_mobile_tests/settings.py
@@ -42,25 +42,38 @@ SECRET_KEY = '0'
 
 ROOT_URLCONF = 'django_mobile_tests.urls'
 
-# List of callables that know how to import templates from various sources.
-TEMPLATE_LOADERS = (
-    ('django_mobile.loader.CachedLoader', (
-        'django_mobile.loader.Loader',
-        'django.template.loaders.filesystem.Loader',
-        'django.template.loaders.app_directories.Loader',
-    )),
-)
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [
+            os.path.join(PROJECT_ROOT, 'templates'),
+        ],
+        'OPTIONS': {
+            'context_processors': [
+                 "django.contrib.auth.context_processors.auth",
+                "django.core.context_processors.debug",
+                "django.core.context_processors.i18n",
+                "django.core.context_processors.media",
+                "django_mobile.context_processors.flavour",
+                "django_mobile.context_processors.is_mobile",
+            ],
+            'loaders': [
+                ('django_mobile.loader.CachedLoader', (
+                    'django_mobile.loader.Loader',
+                    'django.template.loaders.filesystem.Loader',
+                    'django.template.loaders.app_directories.Loader',
+                )),
+            ]
+        }
+    }
+]
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = (
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django_mobile.middleware.MobileDetectionMiddleware',
     'django_mobile.middleware.SetFlavourMiddleware',
-)
-
-TEMPLATE_DIRS = (
-    os.path.join(PROJECT_ROOT, 'templates'),
 )
 
 INSTALLED_APPS = (
@@ -72,15 +85,6 @@ INSTALLED_APPS = (
 
     'django_mobile',
     'django_mobile_tests',
-)
-
-TEMPLATE_CONTEXT_PROCESSORS = (
-    "django.contrib.auth.context_processors.auth",
-    "django.core.context_processors.debug",
-    "django.core.context_processors.i18n",
-    "django.core.context_processors.media",
-    "django_mobile.context_processors.flavour",
-    "django_mobile.context_processors.is_mobile",
 )
 
 

--- a/django_mobile_tests/test_base.py
+++ b/django_mobile_tests/test_base.py
@@ -9,8 +9,6 @@ from django_mobile.conf import settings
 from django_mobile.compat import get_engine
 from django_mobile.middleware import MobileDetectionMiddleware, SetFlavourMiddleware
 
-IS_PYTHON_3 = sys.version > "3"
-
 
 def _reset():
     """
@@ -28,9 +26,7 @@ def str_p3_response(string):
     we decode it to make it comparable to str objects
     ( python 2 compatibility )
     """
-    if IS_PYTHON_3:
-        return string.decode("ASCII")
-    return string
+    return string.decode("ASCII")
 
 
 class BaseTestCase(TestCase):

--- a/django_mobile_tests/test_base.py
+++ b/django_mobile_tests/test_base.py
@@ -59,7 +59,7 @@ class BasicFunctionTests(BaseTestCase):
                 "/", {settings.FLAVOURS_GET_PARAMETER: "mobile",}
             )
             self.assertTrue(settings.FLAVOURS_COOKIE_KEY in response.cookies)
-            self.assertTrue(response.cookies[settings.FLAVOURS_COOKIE_KEY], u"mobile")
+            self.assertTrue(response.cookies[settings.FLAVOURS_COOKIE_KEY], "mobile")
             self.assertContains(response, "Mobile!")
         finally:
             settings.FLAVOURS_STORAGE_BACKEND = original_FLAVOURS_STORAGE_BACKEND
@@ -74,7 +74,7 @@ class BasicFunctionTests(BaseTestCase):
             self.assertEqual(request.session, {})
             set_flavour("mobile", request=request, permanent=True)
             self.assertEqual(
-                request.session, {settings.FLAVOURS_SESSION_KEY: u"mobile"}
+                request.session, {settings.FLAVOURS_SESSION_KEY: "mobile"}
             )
             self.assertEqual(get_flavour(request), "mobile")
 
@@ -232,27 +232,27 @@ class RealAgentNameTests(BaseTestCase):
         client = Client(HTTP_USER_AGENT=agent)
         response = client.get("/")
         if str_p3_response(response.content.strip()) != "Hello full.":
-            self.fail(u"Agent is matched as mobile: %s" % agent)
+            self.fail("Agent is matched as mobile: %s" % agent)
 
     def assertMobileFlavour(self, agent):
         client = Client(HTTP_USER_AGENT=agent)
         response = client.get("/")
         if str_p3_response(response.content.strip()) != "Mobile!":
-            self.fail(u"Agent is not matched as mobile: %s" % agent)
+            self.fail("Agent is not matched as mobile: %s" % agent)
 
     def test_ipad(self):
         self.assertFullFlavour(
-            u"Mozilla/5.0 (iPad; U; CPU OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B334b Safari/531.21.10"
+            "Mozilla/5.0 (iPad; U; CPU OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B334b Safari/531.21.10"
         )
 
     def test_iphone(self):
         self.assertMobileFlavour(
-            u"Mozilla/5.0 (iPhone; U; CPU like Mac OS X; en) AppleWebKit/420+ (KHTML, like Gecko) Version/3.0 Mobile/1A543a Safari/419.3"
+            "Mozilla/5.0 (iPhone; U; CPU like Mac OS X; en) AppleWebKit/420+ (KHTML, like Gecko) Version/3.0 Mobile/1A543a Safari/419.3"
         )
 
     def test_motorola_xoom(self):
         self.assertFullFlavour(
-            u"Mozilla/5.0 (Linux; U; Android 3.0; en-us; Xoom Build/HRI39) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13"
+            "Mozilla/5.0 (Linux; U; Android 3.0; en-us; Xoom Build/HRI39) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13"
         )
 
     def test_opera_mobile_on_android(self):
@@ -260,7 +260,7 @@ class RealAgentNameTests(BaseTestCase):
         Regression test of issue #9
         """
         self.assertMobileFlavour(
-            u"Opera/9.80 (Android 2.3.3; Linux; Opera Mobi/ADR-1111101157; U; en) Presto/2.9.201 Version/11.50"
+            "Opera/9.80 (Android 2.3.3; Linux; Opera Mobi/ADR-1111101157; U; en) Presto/2.9.201 Version/11.50"
         )
 
 

--- a/django_mobile_tests/test_base.py
+++ b/django_mobile_tests/test_base.py
@@ -7,28 +7,31 @@ from mock import MagicMock, Mock, patch
 from django_mobile import get_flavour, set_flavour
 from django_mobile.conf import settings
 from django_mobile.compat import get_engine
-from django_mobile.middleware import MobileDetectionMiddleware, \
-    SetFlavourMiddleware
+from django_mobile.middleware import MobileDetectionMiddleware, SetFlavourMiddleware
 
-IS_PYTHON_3 = sys.version > '3'
+IS_PYTHON_3 = sys.version > "3"
+
 
 def _reset():
-    '''
+    """
     Reset the thread local.
-    '''
+    """
     import django_mobile
+
     del django_mobile._local
     django_mobile._local = threading.local()
 
-def str_p3_response( string ) :
+
+def str_p3_response(string):
     """
     Since response.content is a binary string in python 3,
     we decode it to make it comparable to str objects
     ( python 2 compatibility )
     """
-    if IS_PYTHON_3 :
-        return string.decode( 'ASCII' )
+    if IS_PYTHON_3:
+        return string.decode("ASCII")
     return string
+
 
 class BaseTestCase(TestCase):
     def setUp(self):
@@ -40,52 +43,52 @@ class BaseTestCase(TestCase):
 
 class BasicFunctionTests(BaseTestCase):
     def test_set_flavour(self):
-        set_flavour('full')
-        self.assertEqual(get_flavour(), 'full')
-        set_flavour('mobile')
-        self.assertEqual(get_flavour(), 'mobile')
-        self.assertRaises(ValueError, set_flavour, 'spam')
+        set_flavour("full")
+        self.assertEqual(get_flavour(), "full")
+        set_flavour("mobile")
+        self.assertEqual(get_flavour(), "mobile")
+        self.assertRaises(ValueError, set_flavour, "spam")
 
     def test_set_flavour_with_cookie_backend(self):
         original_FLAVOURS_STORAGE_BACKEND = settings.FLAVOURS_STORAGE_BACKEND
         try:
-            settings.FLAVOURS_STORAGE_BACKEND = 'cookie'
-            response = self.client.get('/')
+            settings.FLAVOURS_STORAGE_BACKEND = "cookie"
+            response = self.client.get("/")
             self.assertFalse(settings.FLAVOURS_COOKIE_KEY in response.cookies)
-            response = self.client.get('/', {
-                settings.FLAVOURS_GET_PARAMETER: 'mobile',
-            })
+            response = self.client.get(
+                "/", {settings.FLAVOURS_GET_PARAMETER: "mobile",}
+            )
             self.assertTrue(settings.FLAVOURS_COOKIE_KEY in response.cookies)
-            self.assertTrue(response.cookies[settings.FLAVOURS_COOKIE_KEY], u'mobile')
-            self.assertContains(response, 'Mobile!')
+            self.assertTrue(response.cookies[settings.FLAVOURS_COOKIE_KEY], u"mobile")
+            self.assertContains(response, "Mobile!")
         finally:
             settings.FLAVOURS_STORAGE_BACKEND = original_FLAVOURS_STORAGE_BACKEND
 
     def test_set_flavour_with_session_backend(self):
         original_FLAVOURS_STORAGE_BACKEND = settings.FLAVOURS_STORAGE_BACKEND
         try:
-            settings.FLAVOURS_STORAGE_BACKEND = 'session'
+            settings.FLAVOURS_STORAGE_BACKEND = "session"
             request = Mock()
             request.session = {}
-            set_flavour('mobile', request=request)
+            set_flavour("mobile", request=request)
             self.assertEqual(request.session, {})
-            set_flavour('mobile', request=request, permanent=True)
-            self.assertEqual(request.session, {
-                settings.FLAVOURS_SESSION_KEY: u'mobile'
-            })
-            self.assertEqual(get_flavour(request), 'mobile')
+            set_flavour("mobile", request=request, permanent=True)
+            self.assertEqual(
+                request.session, {settings.FLAVOURS_SESSION_KEY: u"mobile"}
+            )
+            self.assertEqual(get_flavour(request), "mobile")
 
-            response = self.client.get('/')
-            self.assertFalse('sessionid' in response.cookies)
-            response = self.client.get('/', {
-                settings.FLAVOURS_GET_PARAMETER: 'mobile',
-            })
-            self.assertTrue('sessionid' in response.cookies)
-            sessionid = response.cookies['sessionid'].value
+            response = self.client.get("/")
+            self.assertFalse("sessionid" in response.cookies)
+            response = self.client.get(
+                "/", {settings.FLAVOURS_GET_PARAMETER: "mobile",}
+            )
+            self.assertTrue("sessionid" in response.cookies)
+            sessionid = response.cookies["sessionid"].value
             session = Session.objects.get(session_key=sessionid)
             session_data = session.get_decoded()
             self.assertTrue(settings.FLAVOURS_SESSION_KEY in session_data)
-            self.assertEqual(session_data[settings.FLAVOURS_SESSION_KEY], 'mobile')
+            self.assertEqual(session_data[settings.FLAVOURS_SESSION_KEY], "mobile")
         finally:
             settings.FLAVOURS_STORAGE_BACKEND = original_FLAVOURS_STORAGE_BACKEND
 
@@ -94,108 +97,112 @@ class TemplateLoaderTests(BaseTestCase):
     def test_load_template_on_filesystem(self):
         from django.template.loaders import app_directories, filesystem
 
-        @patch.object(app_directories.Loader, 'load_template')
-        @patch.object(filesystem.Loader, 'load_template')
+        @patch.object(app_directories.Loader, "get_template")
+        @patch.object(filesystem.Loader, "get_template")
         def testing(filesystem_loader, app_directories_loader):
-            filesystem_loader.side_effect = TemplateDoesNotExist('error')
-            app_directories_loader.side_effect = TemplateDoesNotExist('error')
+            filesystem_loader.side_effect = TemplateDoesNotExist("error")
+            app_directories_loader.side_effect = TemplateDoesNotExist("error")
 
             from django_mobile.loader import Loader
+
             loader = Loader(get_engine())
 
-            set_flavour('mobile')
+            set_flavour("mobile")
             try:
-                loader.load_template('base.html', template_dirs=None)
+                loader.get_template("base.html")
             except TemplateDoesNotExist:
                 pass
-            self.assertEqual(filesystem_loader.call_args[0][0], 'mobile/base.html')
-            self.assertEqual(app_directories_loader.call_args[0][0], 'mobile/base.html')
+            self.assertEqual(filesystem_loader.call_args[0][0], "mobile/base.html")
+            self.assertEqual(app_directories_loader.call_args[0][0], "mobile/base.html")
 
-            set_flavour('full')
+            set_flavour("full")
             try:
-                loader.load_template('base.html', template_dirs=None)
+                loader.get_template("base.html")
             except TemplateDoesNotExist:
                 pass
-            self.assertEqual(filesystem_loader.call_args[0][0], 'full/base.html')
-            self.assertEqual(app_directories_loader.call_args[0][0], 'full/base.html')
+            self.assertEqual(filesystem_loader.call_args[0][0], "full/base.html")
+            self.assertEqual(app_directories_loader.call_args[0][0], "full/base.html")
 
         testing()
 
     def test_load_template_source_on_filesystem(self):
         from django.template.loaders import app_directories, filesystem
 
-        @patch.object(app_directories.Loader, 'load_template_source')
-        @patch.object(filesystem.Loader, 'load_template_source')
+        @patch.object(app_directories.Loader, "get_template_sources")
+        @patch.object(filesystem.Loader, "get_template_sources")
         def testing(filesystem_loader, app_directories_loader):
-            filesystem_loader.side_effect = TemplateDoesNotExist('error')
-            app_directories_loader.side_effect = TemplateDoesNotExist('error')
+            filesystem_loader.side_effect = TemplateDoesNotExist("error")
+            app_directories_loader.side_effect = TemplateDoesNotExist("error")
 
             from django_mobile.loader import Loader
+
             loader = Loader(get_engine())
 
-            set_flavour('mobile')
+            set_flavour("mobile")
             try:
-                loader.load_template_source('base.html', template_dirs=None)
+                loader.get_template("base.html")
             except TemplateDoesNotExist:
                 pass
-            self.assertEqual(filesystem_loader.call_args[0][0], 'mobile/base.html')
-            self.assertEqual(app_directories_loader.call_args[0][0], 'mobile/base.html')
+            self.assertEqual(filesystem_loader.call_args[0][0], "mobile/base.html")
+            self.assertEqual(app_directories_loader.call_args[0][0], "mobile/base.html")
 
-            set_flavour('full')
+            set_flavour("full")
             try:
-                loader.load_template_source('base.html', template_dirs=None)
+                loader.get_template("base.html")
             except TemplateDoesNotExist:
                 pass
-            self.assertEqual(filesystem_loader.call_args[0][0], 'full/base.html')
-            self.assertEqual(app_directories_loader.call_args[0][0], 'full/base.html')
+            self.assertEqual(filesystem_loader.call_args[0][0], "full/base.html")
+            self.assertEqual(app_directories_loader.call_args[0][0], "full/base.html")
 
         testing()
 
     def test_functional(self):
         from django.template.loader import render_to_string
-        set_flavour('full')
-        result = render_to_string('index.html')
+
+        set_flavour("full")
+        result = render_to_string("index.html")
         result = result.strip()
-        self.assertEqual(result, 'Hello .')
+        self.assertEqual(result, "Hello .")
         # simulate RequestContext
-        result = render_to_string('index.html', request=RequestContext(Mock()))
+        result = render_to_string("index.html", request=RequestContext(Mock()))
         result = result.strip()
-        self.assertEqual(result, 'Hello full.')
-        set_flavour('mobile')
-        result = render_to_string('index.html')
+        self.assertEqual(result, "Hello full.")
+        set_flavour("mobile")
+        result = render_to_string("index.html")
         result = result.strip()
-        self.assertEqual(result, 'Mobile!')
+        self.assertEqual(result, "Mobile!")
 
     def test_loading_unexisting_template(self):
         from django.template.loader import render_to_string
+
         try:
-            render_to_string('not_existent.html')
+            render_to_string("not_existent.html")
         except TemplateDoesNotExist as e:
-            self.assertEqual(e.args, ('not_existent.html',))
+            self.assertEqual(e.args, ("not_existent.html",))
         else:
-            self.fail('TemplateDoesNotExist was not raised.')
+            self.fail("TemplateDoesNotExist was not raised.")
 
 
 class MobileDetectionMiddlewareTests(BaseTestCase):
-    @patch('django_mobile.middleware.set_flavour')
+    @patch("django_mobile.middleware.set_flavour")
     def test_mobile_browser_agent(self, set_flavour):
         request = Mock()
         request.META = {
-            'HTTP_USER_AGENT': 'My Mobile Browser',
+            "HTTP_USER_AGENT": "My Mobile Browser",
         }
         middleware = MobileDetectionMiddleware()
         middleware.process_request(request)
-        self.assertEqual(set_flavour.call_args, (('mobile', request), {}))
+        self.assertEqual(set_flavour.call_args, (("mobile", request), {}))
 
-    @patch('django_mobile.middleware.set_flavour')
+    @patch("django_mobile.middleware.set_flavour")
     def test_desktop_browser_agent(self, set_flavour):
         request = Mock()
         request.META = {
-            'HTTP_USER_AGENT': 'My Desktop Browser',
+            "HTTP_USER_AGENT": "My Desktop Browser",
         }
         middleware = MobileDetectionMiddleware()
         middleware.process_request(request)
-        self.assertEqual(set_flavour.call_args, (('full', request), {}))
+        self.assertEqual(set_flavour.call_args, (("full", request), {}))
 
 
 class SetFlavourMiddlewareTests(BaseTestCase):
@@ -206,79 +213,88 @@ class SetFlavourMiddlewareTests(BaseTestCase):
         middleware = SetFlavourMiddleware()
         middleware.process_request(request)
         # default flavour is set
-        self.assertEqual(get_flavour(), 'full')
+        self.assertEqual(get_flavour(), "full")
 
-    @patch('django_mobile.middleware.set_flavour')
+    @patch("django_mobile.middleware.set_flavour")
     def test_set_flavour_through_get_parameter(self, set_flavour):
         request = Mock()
         request.META = MagicMock()
-        request.GET = {'flavour': 'mobile'}
+        request.GET = {"flavour": "mobile"}
         middleware = SetFlavourMiddleware()
         middleware.process_request(request)
-        self.assertEqual(set_flavour.call_args,
-            (('mobile', request), {'permanent': True}))
+        self.assertEqual(
+            set_flavour.call_args, (("mobile", request), {"permanent": True})
+        )
 
 
 class RealAgentNameTests(BaseTestCase):
     def assertFullFlavour(self, agent):
         client = Client(HTTP_USER_AGENT=agent)
-        response = client.get('/')
-        if str_p3_response( response.content.strip() ) != 'Hello full.':
-            self.fail(u'Agent is matched as mobile: %s' % agent)
+        response = client.get("/")
+        if str_p3_response(response.content.strip()) != "Hello full.":
+            self.fail(u"Agent is matched as mobile: %s" % agent)
 
     def assertMobileFlavour(self, agent):
         client = Client(HTTP_USER_AGENT=agent)
-        response = client.get('/')
-        if str_p3_response( response.content.strip() ) != 'Mobile!':
-            self.fail(u'Agent is not matched as mobile: %s' % agent)
+        response = client.get("/")
+        if str_p3_response(response.content.strip()) != "Mobile!":
+            self.fail(u"Agent is not matched as mobile: %s" % agent)
 
     def test_ipad(self):
-        self.assertFullFlavour(u'Mozilla/5.0 (iPad; U; CPU OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B334b Safari/531.21.10')
+        self.assertFullFlavour(
+            u"Mozilla/5.0 (iPad; U; CPU OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B334b Safari/531.21.10"
+        )
 
     def test_iphone(self):
-        self.assertMobileFlavour(u'Mozilla/5.0 (iPhone; U; CPU like Mac OS X; en) AppleWebKit/420+ (KHTML, like Gecko) Version/3.0 Mobile/1A543a Safari/419.3')
+        self.assertMobileFlavour(
+            u"Mozilla/5.0 (iPhone; U; CPU like Mac OS X; en) AppleWebKit/420+ (KHTML, like Gecko) Version/3.0 Mobile/1A543a Safari/419.3"
+        )
 
     def test_motorola_xoom(self):
-        self.assertFullFlavour(u'Mozilla/5.0 (Linux; U; Android 3.0; en-us; Xoom Build/HRI39) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13')
+        self.assertFullFlavour(
+            u"Mozilla/5.0 (Linux; U; Android 3.0; en-us; Xoom Build/HRI39) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13"
+        )
 
     def test_opera_mobile_on_android(self):
-        '''
+        """
         Regression test of issue #9
-        '''
-        self.assertMobileFlavour(u'Opera/9.80 (Android 2.3.3; Linux; Opera Mobi/ADR-1111101157; U; en) Presto/2.9.201 Version/11.50')
+        """
+        self.assertMobileFlavour(
+            u"Opera/9.80 (Android 2.3.3; Linux; Opera Mobi/ADR-1111101157; U; en) Presto/2.9.201 Version/11.50"
+        )
 
 
 class RegressionTests(BaseTestCase):
     def setUp(self):
         self.desktop = Client()
         # wap triggers mobile behaviour
-        self.mobile = Client(HTTP_USER_AGENT='wap')
+        self.mobile = Client(HTTP_USER_AGENT="wap")
 
     def test_multiple_browser_access(self):
-        '''
+        """
         Regression test of issue #2
-        '''
-        response = self.desktop.get('/')
-        self.assertEqual( str_p3_response( response.content.strip() ), 'Hello full.')
+        """
+        response = self.desktop.get("/")
+        self.assertEqual(str_p3_response(response.content.strip()), "Hello full.")
 
-        response = self.mobile.get('/')
-        self.assertEqual( str_p3_response( response.content.strip() ), 'Mobile!')
+        response = self.mobile.get("/")
+        self.assertEqual(str_p3_response(response.content.strip()), "Mobile!")
 
-        response = self.desktop.get('/')
-        self.assertEqual( str_p3_response( response.content.strip() ), 'Hello full.')
+        response = self.desktop.get("/")
+        self.assertEqual(str_p3_response(response.content.strip()), "Hello full.")
 
-        response = self.mobile.get('/')
-        self.assertEqual( str_p3_response( response.content.strip() ), 'Mobile!')
+        response = self.mobile.get("/")
+        self.assertEqual(str_p3_response(response.content.strip()), "Mobile!")
 
     def test_cache_page_decorator(self):
-        response = self.mobile.get('/cached/')
-        self.assertEqual( str_p3_response( response.content.strip() ), 'Mobile!')
+        response = self.mobile.get("/cached/")
+        self.assertEqual(str_p3_response(response.content.strip()), "Mobile!")
 
-        response = self.desktop.get('/cached/')
-        self.assertEqual( str_p3_response( response.content.strip() ), 'Hello full.')
+        response = self.desktop.get("/cached/")
+        self.assertEqual(str_p3_response(response.content.strip()), "Hello full.")
 
-        response = self.mobile.get('/cached/')
-        self.assertEqual( str_p3_response( response.content.strip() ), 'Mobile!')
+        response = self.mobile.get("/cached/")
+        self.assertEqual(str_p3_response(response.content.strip()), "Mobile!")
 
-        response = self.desktop.get('/cached/')
-        self.assertEqual( str_p3_response( response.content.strip() ), 'Hello full.')
+        response = self.desktop.get("/cached/")
+        self.assertEqual(str_p3_response(response.content.strip()), "Hello full.")

--- a/django_mobile_tests/test_base.py
+++ b/django_mobile_tests/test_base.py
@@ -158,7 +158,7 @@ class TemplateLoaderTests(BaseTestCase):
         result = result.strip()
         self.assertEqual(result, 'Hello .')
         # simulate RequestContext
-        result = render_to_string('index.html', context_instance=RequestContext(Mock()))
+        result = render_to_string('index.html', request=RequestContext(Mock()))
         result = result.strip()
         self.assertEqual(result, 'Hello full.')
         set_flavour('mobile')

--- a/django_mobile_tests/urls.py
+++ b/django_mobile_tests/urls.py
@@ -8,10 +8,10 @@ from django_mobile.cache import cache_page
 
 
 def index(request):
-    return render(request, 'index.html', {})
+    return render(request, "index.html", {})
 
 
 urlpatterns = [
-    url(r'^$', index),
-    url(r'^cached/$', cache_page(60*10)(index)),
+    url(r"^$", index),
+    url(r"^cached/$", cache_page(60 * 10)(index)),
 ]

--- a/django_mobile_tests/urls.py
+++ b/django_mobile_tests/urls.py
@@ -2,17 +2,16 @@ try:
     from django.conf.urls.defaults import *
 except ImportError:
     from django.conf.urls import *
-from django.shortcuts import render_to_response
-from django.template import RequestContext
+
+from django.shortcuts import render
 from django_mobile.cache import cache_page
 
 
 def index(request):
-    return render_to_response('index.html', {
-    }, context_instance=RequestContext(request))
+    return render(request, 'index.html', {})
 
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^$', index),
     url(r'^cached/$', cache_page(60*10)(index)),
-)
+]

--- a/examples/middleware.py
+++ b/examples/middleware.py
@@ -9,9 +9,9 @@ class MobileTabletDetectionMiddleware(MobileDetectionMiddleware):
     # Example how default middleware could be expanded to provide possibility to detect
     # tablet devices.
 
-    user_agents_android_search = u"(?:android)"
-    user_agents_mobile_search = u"(?:mobile)"
-    user_agents_tablets_search = u"(?:%s)" % u"|".join(("ipad", "tablet",))
+    user_agents_android_search = "(?:android)"
+    user_agents_mobile_search = "(?:mobile)"
+    user_agents_tablets_search = "(?:%s)" % "|".join(("ipad", "tablet",))
 
     def __init__(self):
         super(MobileTabletDetectionMiddleware, self).__init__()

--- a/examples/middleware.py
+++ b/examples/middleware.py
@@ -11,28 +11,32 @@ class MobileTabletDetectionMiddleware(MobileDetectionMiddleware):
 
     user_agents_android_search = u"(?:android)"
     user_agents_mobile_search = u"(?:mobile)"
-    user_agents_tablets_search = u"(?:%s)" % u'|'.join(('ipad', 'tablet', ))
+    user_agents_tablets_search = u"(?:%s)" % u"|".join(("ipad", "tablet",))
 
     def __init__(self):
         super(MobileTabletDetectionMiddleware, self).__init__()
-        self.user_agents_android_search_regex = re.compile(self.user_agents_android_search,
-                                                           re.IGNORECASE)
-        self.user_agents_mobile_search_regex = re.compile(self.user_agents_mobile_search,
-                                                          re.IGNORECASE)
-        self.user_agents_tablets_search_regex = re.compile(self.user_agents_tablets_search,
-                                                           re.IGNORECASE)
+        self.user_agents_android_search_regex = re.compile(
+            self.user_agents_android_search, re.IGNORECASE
+        )
+        self.user_agents_mobile_search_regex = re.compile(
+            self.user_agents_mobile_search, re.IGNORECASE
+        )
+        self.user_agents_tablets_search_regex = re.compile(
+            self.user_agents_tablets_search, re.IGNORECASE
+        )
 
     def process_request(self, request):
         is_tablet = False
 
-        user_agent = request.META.get('HTTP_USER_AGENT')
+        user_agent = request.META.get("HTTP_USER_AGENT")
         if user_agent:
             # Ipad or Blackberry
             if self.user_agents_tablets_search_regex.search(user_agent):
                 is_tablet = True
             # Android-device. If User-Agent doesn't contain Mobile, then it's a tablet
-            elif (self.user_agents_android_search_regex.search(user_agent) and
-                  not self.user_agents_mobile_search_regex.search(user_agent)):
+            elif self.user_agents_android_search_regex.search(
+                user_agent
+            ) and not self.user_agents_mobile_search_regex.search(user_agent):
                 is_tablet = True
             else:
                 # otherwise, let the superclass make decision

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,4 +2,3 @@
 norecursedirs = .git
 
 DJANGO_SETTINGS_MODULE=django_mobile_tests.settings
-DJANGO_CONFIGURATION=

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+norecursedirs = .git
+
+DJANGO_SETTINGS_MODULE=django_mobile_tests.settings
+DJANGO_CONFIGURATION=

--- a/requirements.in
+++ b/requirements.in
@@ -1,9 +1,0 @@
-argparse
-coverage
-django<2       ; python_version<'3.6'
-django==2.2.12 ; python_version=='3.7'
-django==3.0.6  ; python_version=='3.8'
-django-discover-runner
-mock
-pytest
-pytest-django

--- a/requirements.in
+++ b/requirements.in
@@ -1,0 +1,8 @@
+argparse
+coverage
+django==2.2.12 ; python_version=='3.6'
+django==3.0.6 ; python_version=='3.8'
+django-discover-runner
+mock
+pytest
+pytest-django

--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,8 @@
 argparse
 coverage
-django==2.2.12 ; python_version=='3.6'
-django==3.0.6 ; python_version=='3.8'
+django<2       ; python_version<'3.6'
+django==2.2.12 ; python_version=='3.7'
+django==3.0.6  ; python_version=='3.8'
 django-discover-runner
 mock
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,7 @@ attrs==19.3.0
 click==7.1.2
 coverage==5.1
 distlib==0.3.0
-django<2       ; python_version<'3.6'
-django==2.2.12 ; python_version<'3.7'
+django==2.2.12 ; python_version<'3.8'
 django==3.0.6  ; python_version=='3.8'
 django-discover-runner==1.0
 filelock==3.0.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,26 @@
+appdirs==1.4.4
+attr==0.3.1
+attrs==19.3.0
+click==7.1.2
+coverage==5.1
+distlib==0.3.0
+django==2.2.12 ; python_version=='3.6'
+django==3.0.6 ; python_version=='3.8'
+django-discover-runner==1.0
+filelock==3.0.12
+mock==1.0.1
+more-itertools==8.3.0
+packaging==20.4
+pip-tools==5.2.0
+pluggy==0.13.1
+py==1.8.1
+pyparsing==2.4.7
+pytest==5.4.3
+pytest-django==3.9.0
+pytz==2020.1
+six==1.15.0
+sqlparse==0.3.1
+toml==0.10.1
+tox==3.15.1
+virtualenv==20.0.21
+wcwidth==0.2.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,9 @@ attrs==19.3.0
 click==7.1.2
 coverage==5.1
 distlib==0.3.0
-django==2.2.12 ; python_version=='3.6'
-django==3.0.6 ; python_version=='3.8'
+django<2       ; python_version<'3.6'
+django==2.2.12 ; python_version<'3.7'
+django==3.0.6  ; python_version=='3.8'
 django-discover-runner==1.0
 filelock==3.0.12
 mock==1.0.1

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,5 +1,0 @@
-argparse
-coverage
-django-discover-runner
-mock == 1.0.1
-tox

--- a/runtests.py
+++ b/runtests.py
@@ -3,7 +3,7 @@ import argparse
 import os, sys
 
 
-os.environ['DJANGO_SETTINGS_MODULE'] = 'django_mobile_tests.settings'
+os.environ["DJANGO_SETTINGS_MODULE"] = "django_mobile_tests.settings"
 
 
 # Adding current directory to ``sys.path``.
@@ -13,21 +13,21 @@ sys.path.insert(0, parent)
 
 def runtests(*argv):
     argv = list(argv) or [
-        'django_mobile',
-        'django_mobile_tests',
+        "django_mobile",
+        "django_mobile_tests",
     ]
     opts = argparser.parse_args(argv)
 
     if opts.coverage:
         from coverage import coverage
-        test_coverage = coverage(
-            branch=True,
-            source=['django_mobile'])
+
+        test_coverage = coverage(branch=True, source=["django_mobile"])
         test_coverage.start()
 
     # Run tests.
     from django.core.management import execute_from_command_line
-    execute_from_command_line([sys.argv[0], 'test'] + opts.appname)
+
+    execute_from_command_line([sys.argv[0], "test"] + opts.appname)
 
     if opts.coverage:
         test_coverage.stop()
@@ -36,11 +36,17 @@ def runtests(*argv):
         test_coverage.report(file=sys.stdout)
 
 
-argparser = argparse.ArgumentParser(description='Process some integers.')
-argparser.add_argument('appname', nargs='*')
-argparser.add_argument('--no-coverage', dest='coverage', action='store_const',
-    const=False, default=True, help='Do not collect coverage data.')
+argparser = argparse.ArgumentParser(description="Process some integers.")
+argparser.add_argument("appname", nargs="*")
+argparser.add_argument(
+    "--no-coverage",
+    dest="coverage",
+    action="store_const",
+    const=False,
+    default=True,
+    help="Do not collect coverage data.",
+)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     runtests(*sys.argv[1:])

--- a/setup.py
+++ b/setup.py
@@ -85,6 +85,16 @@ setup(
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
     packages=["django_mobile", "django_mobile.cache",],
-    tests_require=["Django", "mock"],
+    install_requires=[
+        "argparse",
+        "coverage",
+        "django<3 ; python_version<'3.8'",
+        "django<4 ; python_version=='3.8'",
+        "django-discover-runner",
+        "mock",
+        "pytest",
+        "pytest-django",
+    ],
+    tests_require=["django", "mock"],
     test_suite="django_mobile_tests.runtests.runtests",
 )

--- a/setup.py
+++ b/setup.py
@@ -56,14 +56,7 @@ class UltraMagicString(object):
         return self.value.split(*args, **kw)
 
 
-if sys.version_info[0] >= 3:
-    long_description = u"\n\n".join((readfile(README_PATH), readfile(CHANGES_PATH),))
-else:
-    long_description = u"\n\n".join(
-        (readfile(README_PATH).decode("utf-8"), readfile(CHANGES_PATH).decode("utf-8"),)
-    )
-    long_description = long_description.encode("utf-8")
-    long_description = UltraMagicString(long_description)
+long_description = "\n\n".join((readfile(README_PATH), readfile(CHANGES_PATH),))
 
 
 setup(
@@ -84,9 +77,9 @@ setup(
         "License :: OSI Approved :: BSD License",
         "Natural Language :: English",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 2.6",
-        "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3.3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Topic :: Internet :: WWW/HTTP",
         "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
         "Topic :: Software Development :: Libraries :: Python Modules",

--- a/setup.py
+++ b/setup.py
@@ -6,22 +6,22 @@ import sys
 from setuptools import setup
 
 
-README_PATH = os.path.join(os.path.dirname(__file__), 'README.rst')
-CHANGES_PATH = os.path.join(os.path.dirname(__file__), 'CHANGES.rst')
+README_PATH = os.path.join(os.path.dirname(__file__), "README.rst")
+CHANGES_PATH = os.path.join(os.path.dirname(__file__), "CHANGES.rst")
 
 
 def readfile(filename):
     if sys.version_info[0] >= 3:
-        return open(filename, 'r', encoding='utf-8').read()
+        return open(filename, "r", encoding="utf-8").read()
     else:
-        return open(filename, 'r').read()
+        return open(filename, "r").read()
 
 
 def get_author(package):
     """
     Return package version as listed in `__version__` in `init.py`.
     """
-    init_py = readfile(os.path.join(package, '__init__.py'))
+    init_py = readfile(os.path.join(package, "__init__.py"))
     author = re.search("__author__ = u?['\"]([^'\"]+)['\"]", init_py).group(1)
     return UltraMagicString(author)
 
@@ -30,15 +30,16 @@ def get_version(package):
     """
     Return package version as listed in `__version__` in `init.py`.
     """
-    init_py = readfile(os.path.join(package, '__init__.py'))
+    init_py = readfile(os.path.join(package, "__init__.py"))
     return re.search("__version__ = ['\"]([^'\"]+)['\"]", init_py).group(1)
 
 
 class UltraMagicString(object):
-    '''
+    """
     Taken from
     http://stackoverflow.com/questions/1162338/whats-the-right-way-to-use-unicode-metadata-in-setup-py
-    '''
+    """
+
     def __init__(self, value):
         self.value = value
 
@@ -46,7 +47,7 @@ class UltraMagicString(object):
         return self.value
 
     def __unicode__(self):
-        return self.value.decode('UTF-8')
+        return self.value.decode("UTF-8")
 
     def __add__(self, other):
         return UltraMagicString(self.value + str(other))
@@ -56,37 +57,33 @@ class UltraMagicString(object):
 
 
 if sys.version_info[0] >= 3:
-    long_description = u'\n\n'.join((
-        readfile(README_PATH),
-        readfile(CHANGES_PATH),
-    ))
+    long_description = u"\n\n".join((readfile(README_PATH), readfile(CHANGES_PATH),))
 else:
-    long_description = u'\n\n'.join((
-        readfile(README_PATH).decode('utf-8'),
-        readfile(CHANGES_PATH).decode('utf-8'),
-    ))
-    long_description = long_description.encode('utf-8')
+    long_description = u"\n\n".join(
+        (readfile(README_PATH).decode("utf-8"), readfile(CHANGES_PATH).decode("utf-8"),)
+    )
+    long_description = long_description.encode("utf-8")
     long_description = UltraMagicString(long_description)
 
 
 setup(
-    name='django-mobile',
-    version=get_version('django_mobile'),
-    url='https://github.com/gregmuellegger/django-mobile',
-    license='BSD',
-    description=u'Detect mobile browsers and serve different template flavours to them.',
+    name="django-mobile",
+    version=get_version("django_mobile"),
+    url="https://github.com/gregmuellegger/django-mobile",
+    license="BSD",
+    description=u"Detect mobile browsers and serve different template flavours to them.",
     long_description=long_description,
-    author=get_author('django_mobile'),
-    author_email='gregor@muellegger.de',
-    keywords='django,mobile',
+    author=get_author("django_mobile"),
+    author_email="gregor@muellegger.de",
+    keywords="django,mobile",
     classifiers=[
-        'Development Status :: 4 - Beta',
-        'Environment :: Web Environment',
-        'Framework :: Django',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: BSD License',
-        'Natural Language :: English',
-        'Operating System :: OS Independent',
+        "Development Status :: 4 - Beta",
+        "Environment :: Web Environment",
+        "Framework :: Django",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: BSD License",
+        "Natural Language :: English",
+        "Operating System :: OS Independent",
         "Programming Language :: Python :: 2.6",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.3",
@@ -94,10 +91,7 @@ setup(
         "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
-    packages=[
-        'django_mobile',
-        'django_mobile.cache',
-    ],
-    tests_require=['Django', 'mock'],
-    test_suite='django_mobile_tests.runtests.runtests',
+    packages=["django_mobile", "django_mobile.cache",],
+    tests_require=["Django", "mock"],
+    test_suite="django_mobile_tests.runtests.runtests",
 )

--- a/tox.ini
+++ b/tox.ini
@@ -15,5 +15,6 @@ deps =
     17: Django >= 1.7, < 1.8
     18: Django >= 1.8, < 1.9
     19: Django >= 1.9, < 1.10
+    20: Django >= 1.10
     master: https://github.com/django/django/tarball/master#egg=Django
     -r{toxinidir}/requirements/tests.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,20 +1,11 @@
 [tox]
-minversion = 1.8
+minversion = 3.15
 envlist =
-    py26-{15,16},
-    py27-{15,16,17,18,19,master},
-    py33-{17,18,master},
-    py34-{17,18,19,master},
-    pypy-{15,16,17,18,19,master}
+    py36,
+    py37,
+    py38,
 
 [testenv]
 commands = python runtests.py
 deps =
-    15: Django >= 1.5, < 1.6
-    16: Django >= 1.6, < 1.7
-    17: Django >= 1.7, < 1.8
-    18: Django >= 1.8, < 1.9
-    19: Django >= 1.9, < 1.10
-    20: Django >= 1.10
-    master: https://github.com/django/django/tarball/master#egg=Django
-    -r{toxinidir}/requirements/tests.txt
+    -r{toxinidir}/requirements.txt


### PR DESCRIPTION
Porting django-mobile to Django 2.2/3.

This is a one way port. No longer compatible with "Django<2".